### PR TITLE
rabbitmq コンテナを 3.13-alpine にアップデートしました

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2024-07-25  Ichiro TAKAHASHI  <takahashi@fixpoint.co.jp>
+
+	* rabbitmq コンテナを 3.13-alpine にアップデートしました。 (#26)
+
 2024-07-19  Ichiro TAKAHASHI  <takahashi@fixpoint.co.jp>
 
 	* ホスト名が FQDN でないときに rabbitmq-server が正常動作しない場合が問題を修正しました。(#16)

--- a/ke2/services/rabbitmq.yml
+++ b/ke2/services/rabbitmq.yml
@@ -1,6 +1,6 @@
 services:
   rabbitmq:
-    image: registry.hub.docker.com/library/rabbitmq:3.12-alpine
+    image: registry.hub.docker.com/library/rabbitmq:3.13-alpine
     hostname: mq-${HOSTNAME}
     environment:
       RABBITMQ_DATA_DIR: /var/lib/rabbitmq


### PR DESCRIPTION
rabbitmq コンテナを 3.13-alpine にアップデートしました。

- 最新の RabbitMQ 3.13.6 が入ったコンテナが利用できました。
- single/extdb 構成で正常動作することを確認しました。
- cluster/swarm 3台構成で正常動作することを確認しました。