### PR TITLE
issue27: 監査ログ(audit.log)の記録レベル値を環境変数 AUDIT_LOGGING_LEVEL で指定できるようにしました

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2024-07-25  Ichiro TAKAHASHI  <takahashi@fixpoint.co.jp>
 
+	* 監査ログ(audit.log)の記録レベル値を環境変数 AUDIT_LOGGING_LEVEL で指定できるようにしました。(#28)
+
 	* rabbitmq コンテナを 3.13-alpine にアップデートしました。 (#26)
 
 2024-07-19  Ichiro TAKAHASHI  <takahashi@fixpoint.co.jp>

--- a/ke2/services/kompira.yml
+++ b/ke2/services/kompira.yml
@@ -17,6 +17,7 @@ x-kompira-common-environ:
   CACHE_URL: ${CACHE_URL:-redis://redis:6379}
   LANGUAGE_CODE: ${LANGUAGE_CODE:-ja}
   TZ: ${TZ:-Asia/Tokyo}
+  KOMPIRA_AUDIT_LOGGING_LEVEL: ${AUDIT_LOGGING_LEVEL:-}
 
 services:
   kengine:


### PR DESCRIPTION
#27 に対応しました。

- 環境変数 `AUDIT_LOGGING_LEVEL` で監査ログの「記録レベル値」を設定できるようにしました。
    - 本体側に設定する環境変数 `KOMPIRA_AUDIT_LOGGING_LEVEL` が現状 undocumented なため、別途本体側のマニュアルもしくは ke2-admin-manual に追記する
- 監査ログ設定ファイル kompira_audit.yaml の `logging_level` の設定値より優先して適用されます。
- `AUDIT_LOGGING_LEVEL=0` にすると全ての操作レベル値の監査ログが記録されることを確認済みです。
- `AUDIT_LOGGING_LEVEL=4` にすると（現状では操作レベル3が最大のため）まったく監査ログが記録されなくなることを確認済みです。
