### PR TITLE
Feature/issue22 nginx uwsgi timeout

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2024-07-25  Ichiro TAKAHASHI  <takahashi@fixpoint.co.jp>
 
+	* nginx -> uwsgi の send/recv タイムアウトを 300 秒に設定しました。(#22)
+
 	* 監査ログ(audit.log)の記録レベル値を環境変数 AUDIT_LOGGING_LEVEL で指定できるようにしました。(#28)
 
 	* rabbitmq コンテナを 3.13-alpine にアップデートしました。 (#26)

--- a/configs/nginx.conf
+++ b/configs/nginx.conf
@@ -2,10 +2,9 @@ upstream django {
     server kompira:8000;
 }
 
-# タイムアウトの設定
-proxy_connect_timeout 30;
-proxy_send_timeout 300;
-proxy_read_timeout 300;
+# uwsgi タイムアウトの設定
+uwsgi_send_timeout 300;
+uwsgi_read_timeout 300;
 
 server {
     # HTTPの80番ポートを指定


### PR DESCRIPTION
#22 に対応しました。

- nginx -> uwsgi の send/recv タイムアウトを 300 秒に設定しました(デフォルトは60秒)。
- 大きめの import/export で `504 Gateway Time-out` が出なくなること（短くすると出ること）を確認しました。