### PR TITLE
Feature/issue30 update container version

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2024-07-26  Ichiro TAKAHASHI  <takahashi@fixpoint.co.jp>
+
+	* nginx コンテナのバージョンを 1.27-alpine にアップデートしました。(#30)
+
+	* postgresql コンテナのバージョンを 16.3-alpine にアップデートしました。PGDATA 領域のボリューム名を変更しました。(#30)
+
 2024-07-25  Ichiro TAKAHASHI  <takahashi@fixpoint.co.jp>
 
 	* nginx -> uwsgi の send/recv タイムアウトを 300 秒に設定しました。(#22)

--- a/ke2/services/nginx.yml
+++ b/ke2/services/nginx.yml
@@ -1,6 +1,6 @@
 services:
   nginx:
-    image: registry.hub.docker.com/library/nginx:1.25-alpine
+    image: registry.hub.docker.com/library/nginx:1.27-alpine
     hostname: nx-${HOSTNAME}
     environment:
       - TZ=${TZ:-Asia/Tokyo}

--- a/ke2/services/postgres.yml
+++ b/ke2/services/postgres.yml
@@ -1,12 +1,14 @@
 services:
   postgres:
-    image: registry.hub.docker.com/library/postgres:15-alpine
+    # MEMO: potgrsql のメジャーバージョンを変更するときは PGDATA 領域のボリューム名も変更すること
+    image: registry.hub.docker.com/library/postgres:16.3-alpine
     hostname: db-${HOSTNAME}
     environment:
       POSTGRES_PASSWORD: kompira
       POSTGRES_USER: kompira
       TZ: ${TZ:-Asia/Tokyo}
     volumes:
-      - ${PGDATA:-kompira_db}:/var/lib/postgresql/data
+      - ${PGDATA:-kompira_pg16}:/var/lib/postgresql/data
 volumes:
-  kompira_db:
+  # MEMO: postgresql のメジャーバージョンごとにボリュームを分けておく
+  kompira_pg16:


### PR DESCRIPTION
#30 に対応しました。

- ke2/single/basic 環境でコンテナがアップデートできていること、正常に動作していることを確認済みです。
  ```
  # docker exec -it $(docker ps -q -f name=nginx) nginx -v
  nginx version: nginx/1.27.0
  # docker exec -it $(docker ps -q -f name=postgres) postgres --version
  postgres (PostgreSQL) 16.3
  ```
- postgresql の PGDATA 領域のボリューム名変更にともない、以前のボリュームが残っていることを確認済みです。
  ```
  # docker volume inspect ke2_kompira_db ke2_kompira_pg16
  [
      {
          "CreatedAt": "2024-07-26T10:32:01+09:00",
          "Driver": "local",
          "Labels": {
              "com.docker.compose.project": "ke2",
              "com.docker.compose.version": "2.28.1",
              "com.docker.compose.volume": "kompira_db"
          },
          "Mountpoint": "/var/lib/docker/volumes/ke2_kompira_db/_data",
          "Name": "ke2_kompira_db",
          "Options": null,
          "Scope": "local"
      },
      {
          "CreatedAt": "2024-07-26T11:30:49+09:00",
          "Driver": "local",
          "Labels": {
              "com.docker.compose.project": "ke2",
              "com.docker.compose.version": "2.28.1",
              "com.docker.compose.volume": "kompira_pg16"
          },
          "Mountpoint": "/var/lib/docker/volumes/ke2_kompira_pg16/_data",
          "Name": "ke2_kompira_pg16",
          "Options": null,
          "Scope": "local"
      }
  ]
  ```