### PR TITLE
Feature/issue44 docker config envsubst

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2024-08-20  Ichiro TAKAHASHI  <takahashi@fixpoint.co.jp>
 
+	* 環境変数 ${KOMPIRA_HOST}, ${KOMPIRA_PORT} で nginx の upstream django サーバを指定できるようにしました。(#44)
+
 	* docker-compose-plugin について v2.24.6 以上が必要であることを追記しました。(#41)
 
 2024-08-01  Ichiro TAKAHASHI  <takahashi@fixpoint.co.jp>

--- a/configs/nginx.conf
+++ b/configs/nginx.conf
@@ -1,5 +1,6 @@
+# kompira サーバの設定 (環境変数は起動時に envsubst で置換する)
 upstream django {
-    server kompira:8000;
+    server ${KOMPIRA_HOST}:${KOMPIRA_PORT};
 }
 
 # uwsgi タイムアウトの設定

--- a/ke2/services/nginx.yml
+++ b/ke2/services/nginx.yml
@@ -5,6 +5,8 @@ services:
     environment:
       - TZ=${TZ:-Asia/Tokyo}
       - NGINX_ENVSUBST_FILTER=^KOMPIRA
+      - KOMPIRA_HOST=${KOMPIRA_HOST:-kompira}
+      - KOMPIRA_PORT=${KOMPIRA_PORT:-8000}
     configs:
       # MEMO: /etc/nginx/templates/*.template は起動時に環境変数が展開されて /etc/nginx/conf.d/* に書き出される
       - source: nginx-config

--- a/ke2/services/nginx.yml
+++ b/ke2/services/nginx.yml
@@ -4,9 +4,11 @@ services:
     hostname: nx-${HOSTNAME}
     environment:
       - TZ=${TZ:-Asia/Tokyo}
+      - NGINX_ENVSUBST_FILTER=^KOMPIRA
     configs:
+      # MEMO: /etc/nginx/templates/*.template は起動時に環境変数が展開されて /etc/nginx/conf.d/* に書き出される
       - source: nginx-config
-        target: /etc/nginx/conf.d/default.conf
+        target: /etc/nginx/templates/default.conf.template
     volumes:
       - ${KOMPIRA_VAR_DIR:-kompira_var}:/var/opt/kompira
       - ${KOMPIRA_SSL_DIR:-../../ssl}:/etc/nginx/ssl:ro


### PR DESCRIPTION
#44 に対応しました。

- 環境変数 `${KOMPIRA_HOST}`, `${KOMPIRA_PORT}` で nginx の upstream django サーバを指定できるようにしました。
- シングル構成で従来通り kompira:8000 で接続することを動作確認しています。