### PR TITLE
Feature/issue58 fixed kompira tag 202

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2024-10-16  Ichiro TAKAHASHI  <takahashi@fixpoint.co.jp>
+
+	* KOMPIRA_IMAGE_TAG のデフォルト値はその時点で公開されている最新イメージのタグとなるようにしました。(#58)
+
 2024-09-02  Ichiro TAKAHASHI  <takahashi@fixpoint.co.jp>
 
 	* ログ設定 (LOGGING_XXX, AUDIT_LOGGING_XXX) を環境変数で指定できるようにしました。(#54)

--- a/Environment.md
+++ b/Environment.md
@@ -8,7 +8,7 @@
 |-----------------------|-----------------------------------------------------|----------------------------|
 | `HOSTNAME`            | (下記参照)                                          | ホスト名                   |
 | `KOMPIRA_IMAGE_NAME`  | "kompira.azurecr.io/kompira-enterprise"             | Kompira イメージ           |
-| `KOMPIRA_IMAGE_TAG`   | "latest"                                            | Kompira タグ               |
+| `KOMPIRA_IMAGE_TAG`   | (下記参照)                                          | Kompira タグ               |
 | `DATABASE_URL`        | "pgsql://kompira@//var/run/postgresql/kompira"      | データベースの接続先       |
 | `AMQP_URL`            | "amqp://guest:guest@localhost:5672"                 | メッセージキューの接続先   |
 | `CACHE_URL`           | "redis://localhost:6379"                            | キャッシュの接続先         |
@@ -29,6 +29,8 @@
 
 デプロイする Kompira コンテナのイメージとタグを指定します。
 独自に用意したコンテナイメージや、特定のバージョンのコンテナイメージを利用したい場合にこの環境変数で指定することができます。
+
+KOMPIRA_IMAGE_TAG のデフォルト値は ke2-docker 更新時点で公開されていた最新の kompira コンテナイメージを示しています（例えば "2.0.2" など）。KOMPIRA_IMAGE_TAG に "latest" と指定すると、デプロイ時に公開されている最新の kompira コンテナイメージを利用することができます。
 
 ## DATABASE_URL / AMQP_URL / CACHE_URL
 

--- a/ke2/services/jobmngrd.yml
+++ b/ke2/services/jobmngrd.yml
@@ -1,6 +1,6 @@
 services:
   jobmngrd:
-    image: ${KOMPIRA_IMAGE_NAME:-kompira.azurecr.io/kompira-enterprise}:${KOMPIRA_IMAGE_TAG:-latest}
+    image: ${KOMPIRA_IMAGE_NAME:-kompira.azurecr.io/kompira-enterprise}:${KOMPIRA_IMAGE_TAG:-2.0.2}
     hostname: jm-${HOSTNAME:?HOSTNAME must be set}
     init: true
     environment:

--- a/ke2/services/kompira.yml
+++ b/ke2/services/kompira.yml
@@ -1,6 +1,6 @@
 x-kompira-common-settings:
   &kompira-common-settings
-  image: ${KOMPIRA_IMAGE_NAME:-kompira.azurecr.io/kompira-enterprise}:${KOMPIRA_IMAGE_TAG:-latest}
+  image: ${KOMPIRA_IMAGE_NAME:-kompira.azurecr.io/kompira-enterprise}:${KOMPIRA_IMAGE_TAG:-2.0.2}
   configs:
     - source: kompira-audit
       target: /opt/kompira/kompira_audit.yaml


### PR DESCRIPTION
#58 に対応しました。

- 再デプロイ時に意図せずイメージがアップデートしない（事故を防ぐ）ように、KOMPIRA_IMAGE_TAG のデフォルト値を固定値にしました。
- KOMPIRA_IMAGE_TAG のデフォルト値はその時点で公開されている最新イメージのタグ（今回は `”2.0.2”`）にします。
- 今後、kompira イメージがリリースされるたびに、基本的には ke2-docker 側も追随するようにします。