### PR TITLE
issue68: jobmngrdコンテナに環境変数 DATABASE_URL, CACHE_URL を渡せるようにしました

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2025-01-17  Ichiro TAKAHASHI  <takahashi@fixpoint.co.jp>
+
+	* jobmngrdコンテナに環境変数 DATABASE_URL, CACHE_URL を渡せるようにしました。(#68)
+
 2024-12-16  Hasan Mahamudul  <hasan@fixpoint.co.jp>
 
 	* [nginx] client request header size の設定値を 2*32KB に変更しました。(#61)

--- a/ke2/services/jobmngrd.yml
+++ b/ke2/services/jobmngrd.yml
@@ -4,6 +4,8 @@ services:
     hostname: jm-${HOSTNAME:?HOSTNAME must be set}
     init: true
     environment:
+      DATABASE_URL: ${DATABASE_URL:-pgsql://kompira:kompira@${DATABASE_HOST:-postgres}:5432/kompira}
+      CACHE_URL: ${CACHE_URL:-redis://redis:6379}
       AMQP_URL: ${AMQP_URL:-amqp://guest:guest@rabbitmq:5672}
       TZ: ${TZ:-Asia/Tokyo}
       LOGGING_NAME: jobmngrd


### PR DESCRIPTION
#68 に対応しました。

- single/basic をデプロイして実行ジョブで "manage.py export_data" が実行できること（データをエクスポートできること）を確認しました。