### PR TITLE
Feature/issue71 nginx server tokens off

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2025-01-21  Ichiro TAKAHASHI  <takahashi@fixpoint.co.jp>
+
+	* HTTP レスポンスヘッダの Server: にサーバのバージョン情報が載らないようにしました。(#71)
+
 2025-01-17  Ichiro TAKAHASHI  <takahashi@fixpoint.co.jp>
 
 	* jobmngrdコンテナに環境変数 DATABASE_URL, CACHE_URL を渡せるようにしました。(#68)

--- a/configs/nginx.conf
+++ b/configs/nginx.conf
@@ -7,6 +7,9 @@ upstream django {
 uwsgi_send_timeout 300;
 uwsgi_read_timeout 300;
 
+# レスポンスヘッダの Server: にサーバのバージョン情報が載らないようにする
+server_tokens off;
+
 server {
     # HTTPの80番ポートを指定
     listen 80;


### PR DESCRIPTION
#71 に対応しました。

- シングル構成でデプロイして、HTTP/HTTPS アクセスで Server ヘッダからバージョン情報が削除されていることを確認しています。

## 変更前
```
# curl -k --head http://localhost
HTTP/1.1 301 Moved Permanently
Server: nginx/1.27.3
Date: Tue, 21 Jan 2025 06:54:33 GMT
Content-Type: text/html
Content-Length: 169
Connection: keep-alive
Location: https://localhost/

# curl -k --head https://localhost
HTTP/1.1 302 Found
Server: nginx/1.27.3
Date: Tue, 21 Jan 2025 06:54:47 GMT
Content-Type: text/html; charset=utf-8
Content-Length: 0
Connection: keep-alive
Location: /.login?next=/
Vary: Accept, Accept-Language, Cookie
Allow: 
X-Frame-Options: DENY
Content-Language: ja
X-Content-Type-Options: nosniff
Referrer-Policy: same-origin
Cross-Origin-Opener-Policy: same-origin
```

## 変更後
```
# curl -k --head http://localhost
HTTP/1.1 301 Moved Permanently
Server: nginx
Date: Tue, 21 Jan 2025 06:56:25 GMT
Content-Type: text/html
Content-Length: 162
Connection: keep-alive
Location: https://localhost/

# curl -k --head https://localhost
HTTP/1.1 302 Found
Server: nginx
Date: Tue, 21 Jan 2025 06:56:29 GMT
Content-Type: text/html; charset=utf-8
Content-Length: 0
Connection: keep-alive
Location: /.login?next=/
Vary: Accept, Accept-Language, Cookie
Allow: 
X-Frame-Options: DENY
Content-Language: ja
X-Content-Type-Options: nosniff
Referrer-Policy: same-origin
Cross-Origin-Opener-Policy: same-origin

```