### PR TITLE
Feature/issue69 update ca certificates

### DIFF
--- a/ke2/services/jobmngrd.yml
+++ b/ke2/services/jobmngrd.yml
@@ -15,6 +15,7 @@ services:
       LOGGING_BACKUP: ${JOBMNGRD_LOGGING_BACKUP:-${LOGGING_BACKUP:-7}}
       LOGGING_WHEN: ${JOBMNGRD_LOGGING_WHEN:-${LOGGING_WHEN:-MIDNIGHT}}
       LOGGING_INTERVAL: ${JOBMNGRD_LOGGING_INTERVAL:-${LOGGING_INTERVAL:-1}}
+      REQUESTS_CA_BUNDLE: ${REQUESTS_CA_BUNDLE:-/etc/ssl/certs/ca-certificates.crt}
     configs:
       - source: kompira-config
         target: /opt/kompira/kompira.conf

--- a/ke2/services/jobmngrd.yml
+++ b/ke2/services/jobmngrd.yml
@@ -21,6 +21,7 @@ services:
     volumes:
       - ${KOMPIRA_VAR_DIR:-kompira_var}:/var/opt/kompira
       - ${KOMPIRA_LOG_DIR:-kompira_log}:/var/log/kompira
+      - ${KOMPIRA_SSL_DIR:-../../ssl}:/opt/kompira/ssl:ro
     extra_hosts:
       - host.docker.internal:host-gateway
     command: ["jobmngrd"]

--- a/ke2/services/kompira.yml
+++ b/ke2/services/kompira.yml
@@ -20,6 +20,7 @@ x-kompira-common-environ:
   CACHE_URL: ${CACHE_URL:-redis://redis:6379}
   LANGUAGE_CODE: ${LANGUAGE_CODE:-ja}
   TZ: ${TZ:-Asia/Tokyo}
+  REQUESTS_CA_BUNDLE: ${REQUESTS_CA_BUNDLE:-/etc/ssl/certs/ca-certificates.crt}
 
 services:
   kengine:

--- a/ke2/services/kompira.yml
+++ b/ke2/services/kompira.yml
@@ -7,6 +7,7 @@ x-kompira-common-settings:
   volumes:
     - ${KOMPIRA_VAR_DIR:-kompira_var}:/var/opt/kompira
     - ${KOMPIRA_LOG_DIR:-kompira_log}:/var/log/kompira
+    - ${KOMPIRA_SSL_DIR:-../../ssl}:/opt/kompira/ssl:ro
   extra_hosts:
     - host.docker.internal:host-gateway
   sysctls:


### PR DESCRIPTION
#69 に対応しました。

- kompira,kengine,jobmngrd コンテナで $KOMPIRA_SSL_DIR を /opt/kompira/ssl にマウントするようにしました。
    - KOMPIRA_SSL_DIR に配置した CA 証明書にコンテナからアクセスできるようになります。
- kompira,kengine,jobmngrd コンテナで requests モジュールが参照する CA 証明書を /etc/ssl/certs/ca-certificates.crt としました。
    - 環境変数 REQUESTS_CA_BUNDLE をデフォルトで /etc/ssl/certs/ca-certificates.crt と設定するようにました。
    - requests を利用する https アクセスにおいて、update-ca-certificates で更新された CA 証明書を参照するようになります。

なお、これらにはコンテナ側の https://github.com/fixpoint/kompira-v2/issues/216 の対応 (https://github.com/fixpoint/kompira-v2/pull/244) が必要になります。