### PR TITLE
issue86: SSL証明書リロードスクリプト reload-cert.sh を追加しました

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2025-05-09  Ichiro TAKAHASHI  <takahashi@fixpoint.co.jp>
+
+	* SSL証明書リロードスクリプト reload-cert.sh を追加しました。(#86)
+
 2025-03-25  Hasan Mahamudul  <hasan@fixpoint.co.jp>
 
 	* ACI にも ngninx の共通設定を利用できるにしました。(#75)

--- a/ke2/services/jobmngrd.yml
+++ b/ke2/services/jobmngrd.yml
@@ -15,12 +15,14 @@ services:
       LOGGING_BACKUP: ${JOBMNGRD_LOGGING_BACKUP:-${LOGGING_BACKUP:-7}}
       LOGGING_WHEN: ${JOBMNGRD_LOGGING_WHEN:-${LOGGING_WHEN:-MIDNIGHT}}
       LOGGING_INTERVAL: ${JOBMNGRD_LOGGING_INTERVAL:-${LOGGING_INTERVAL:-1}}
+      REQUESTS_CA_BUNDLE: ${REQUESTS_CA_BUNDLE:-/etc/ssl/certs/ca-certificates.crt}
     configs:
       - source: kompira-config
         target: /opt/kompira/kompira.conf
     volumes:
       - ${KOMPIRA_VAR_DIR:-kompira_var}:/var/opt/kompira
       - ${KOMPIRA_LOG_DIR:-kompira_log}:/var/log/kompira
+      - ${KOMPIRA_SSL_DIR:-../../ssl}:/opt/kompira/ssl:ro
     extra_hosts:
       - host.docker.internal:host-gateway
     command: ["jobmngrd"]

--- a/ke2/services/kompira.yml
+++ b/ke2/services/kompira.yml
@@ -7,6 +7,7 @@ x-kompira-common-settings:
   volumes:
     - ${KOMPIRA_VAR_DIR:-kompira_var}:/var/opt/kompira
     - ${KOMPIRA_LOG_DIR:-kompira_log}:/var/log/kompira
+    - ${KOMPIRA_SSL_DIR:-../../ssl}:/opt/kompira/ssl:ro
   extra_hosts:
     - host.docker.internal:host-gateway
   sysctls:
@@ -19,6 +20,7 @@ x-kompira-common-environ:
   CACHE_URL: ${CACHE_URL:-redis://redis:6379}
   LANGUAGE_CODE: ${LANGUAGE_CODE:-ja}
   TZ: ${TZ:-Asia/Tokyo}
+  REQUESTS_CA_BUNDLE: ${REQUESTS_CA_BUNDLE:-/etc/ssl/certs/ca-certificates.crt}
 
 services:
   kengine:

--- a/scripts/reload-cert.sh
+++ b/scripts/reload-cert.sh
@@ -1,0 +1,31 @@
+#! /bin/bash
+#
+# SSL 証明書リロードスクリプト
+#
+# 各 docker コンテナに SSL 証明書をリロードさせます。
+# ホスト上で SSL 証明書を更新したときなどに利用します。
+#
+# SSL証明書/秘密鍵: server.crt, server.key
+#
+set -eu
+
+# コンテナ名
+: ${NGINX:=nginx}
+: ${RABBITMQ:=rabbitmq}
+
+# docker exec コマンド
+: ${DOCKER_EXEC:="docker exec -it"}
+
+# Nginx コンテナに SSL 証明書をリロードさせる
+cid_nginx=$(docker ps -q -f name=$NGINX)
+if [ -n "$cid_nginx" ]; then
+    echo "Reload SSL certificate in $NGINX container ($cid_nginx)"
+    $DOCKER_EXEC $cid_nginx nginx -s reload
+fi
+
+# RabbitMQ コンテナに SSL 証明書をリロードさせる
+cid_rabbitmq=$(docker ps -q -f name=$RABBITMQ)
+if [ -n "$cid_rabbitmq" ]; then
+    echo "Reload SSL certificate in $RABBITMQ container ($cid_rabbitmq)"
+    $DOCKER_EXEC $cid_rabbitmq sh -c "/bin/cp -f -a -r -T /run/.kompira_ssl /etc/rabbitmq/ssl && chown -R rabbitmq:rabbitmq /etc/rabbitmq/ssl && rabbitmqctl eval 'ssl:clear_pem_cache().'"
+fi


### PR DESCRIPTION
#86 に対応しました。

- nginx, rabbitmq 各コンテナに SSL 証明書をリロードさせるスクリプト reload-cert.sh を追加しました。
- 使い方については、ke2-admin-manual に追記する予定です。

ホスト上で SSL 証明書を更新した状態で、（コンテナに HTTPS アクセスして）リロード前は以前の SSL 証明書であること、リロードスクリプト実行した後は更新された SSL 証明書になっていることを確認しています。

### リロード前
```
# openssl s_client -connect localhost:5671 -showcerts < /dev/null 2>/dev/null | openssl x509 -noout -subject -dates
subject=CN=ke203a1-test1a.japaneast.cloudapp.azure.com
notBefore=May  7 06:18:12 2025 GMT
notAfter=Aug  5 06:18:11 2025 GMT
# openssl s_client -connect localhost:443 -showcerts < /dev/null 2>/dev/null | openssl x509 -noout -subject -dates
subject=CN=ke203a1-test1a.japaneast.cloudapp.azure.com
notBefore=May  7 06:18:12 2025 GMT
notAfter=Aug  5 06:18:11 2025 GMT
```

### リロード実行
```
# ../../../scripts/reload-cert.sh 
Reload SSL certificate in nginx container
2025/05/07 16:42:21 [notice] 37#37: signal process started
Reload SSL certificate in rabbitmq container
ok
```

### リロード後
```
# openssl s_client -connect localhost:443 -showcerts < /dev/null 2>/dev/null | openssl x509 -noout -subject -dates
subject=CN=ke203a1-test1a.japaneast.cloudapp.azure.com
notBefore=May  7 06:43:27 2025 GMT
notAfter=Aug  5 06:43:26 2025 GMT    ★ 有効期限が伸びている
# openssl s_client -connect localhost:5671 -showcerts < /dev/null 2>/dev/null | openssl x509 -noout -subject -dates
subject=CN=ke203a1-test1a.japaneast.cloudapp.azure.com
notBefore=May  7 06:43:27 2025 GMT
notAfter=Aug  5 06:43:26 2025 GMT    ★ 有効期限が伸びている

```