### PR TITLE
support-python3.13: (WIP) Update scripts/create-cert.sh

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2026-02-20  Ichiro TAKAHASHI  <takahashi@fixpoint.co.jp>
+
+	* create-cert.sh: Python 3.13 および厳格なSSL検証環境に対応しました。(#95)
+
 2025-05-23  Hasan Mahamudul  <hasan@fixpoint.co.jp>
 
 	* KE2 ACI をサブネット内にデプロイできるようにしました。(#89)

--- a/scripts/create-cert.sh
+++ b/scripts/create-cert.sh
@@ -24,7 +24,6 @@ BASE_DIR=$(dirname $(dirname $(readlink -f $0)))
 : ${CERT_CN:="$(hostname)"}
 : ${CERT_SAN_ALTNAMES:="DNS:${CERT_CN}"}
 : ${CERT_SUBJECT:="/CN=${CERT_CN}"}
-: ${CERT_SAN:="subjectAltName = ${CERT_SAN_ALTNAMES}"}
 : ${CERT_DAYS:=3650}
 : ${CERT_KEYTYPE:="rsa:2048"}
 
@@ -62,14 +61,25 @@ fi
 # CA 証明書の作成
 if [ ! -f $SOURCE/$CA_NAME.crt ]; then
     echo "Create local CA certificate: $SOURCE/$CA_NAME.crt"
-    $DOCKER_RUN -v $SOURCE:$TARGET $IMAGE openssl req -x509 -noenc -newkey $CA_KEYTYPE -days $CA_DAYS -out $TARGET/$CA_NAME.crt -keyout $TARGET/$CA_NAME.key -subj "$CA_SUBJECT"
+    $DOCKER_RUN -v $SOURCE:$TARGET $IMAGE openssl req -x509 -noenc -newkey $CA_KEYTYPE -days $CA_DAYS -out $TARGET/$CA_NAME.crt -keyout $TARGET/$CA_NAME.key -subj "$CA_SUBJECT" \
+    -addext "subjectKeyIdentifier = hash" \
+    -addext "basicConstraints = critical, CA:true" \
+    -addext "keyUsage = critical, cRLSign, keyCertSign"
 fi
 # SSL 証明書の作成
 if [ ! -f $SOURCE/$CERT_NAME.crt ]; then
     echo "Create SSL (self-signed) certificate: $SOURCE/$CERT_NAME.crt"
     $DOCKER_RUN -v $SOURCE:$TARGET $IMAGE openssl req -new -newkey $CERT_KEYTYPE -noenc -sha256 -out $TARGET/$CERT_NAME.csr -keyout $TARGET/$CERT_NAME.key -subj "$CERT_SUBJECT"
-    echo "$CERT_SAN" > $SOURCE/$CERT_NAME.ext
-    $DOCKER_RUN -v $SOURCE:$TARGET $IMAGE openssl x509 -req -days $CERT_DAYS -in $TARGET/$CERT_NAME.csr -out $TARGET/$CERT_NAME.crt -CA $TARGET/$CA_NAME.crt -CAkey $TARGET/$CA_NAME.key -CAcreateserial -extfile $TARGET/$CERT_NAME.ext
+    cat <<__EOF__ > $SOURCE/$CERT_NAME.ext
+[ v3_req ]
+authorityKeyIdentifier = keyid
+subjectKeyIdentifier = hash
+basicConstraints = critical, CA:false
+keyUsage = critical, digitalSignature
+extendedKeyUsage = serverAuth, clientAuth
+subjectAltName = ${CERT_SAN_ALTNAMES}
+__EOF__
+    $DOCKER_RUN -v $SOURCE:$TARGET $IMAGE openssl x509 -req -days $CERT_DAYS -in $TARGET/$CERT_NAME.csr -out $TARGET/$CERT_NAME.crt -CA $TARGET/$CA_NAME.crt -CAkey $TARGET/$CA_NAME.key -CAcreateserial -extfile $TARGET/$CERT_NAME.ext -extensions v3_req
 else
     echo "WARNING: SSL certificate $SOURCE/$CERT_NAME.crt already exists"
 fi


### PR DESCRIPTION
#95 に対応しました。

- CA証明書の属性追加
  - basicConstraints = CA:true, keyUsage (cRLSign, keyCertSign) を追加し、正規のCAとしての属性を明示しました。
  - subjectKeyIdentifier を追加しました。
- サーバー証明書の属性追加
  - basicConstraints = CA:false を明示しました。
  - extendedKeyUsage (serverAuth, clientAuth) を追加し、用途を制限しました。
  - authorityKeyIdentifier, subjectKeyIdentifier を追加し、信頼チェーンの検証を確実にしました。
