### PR TITLE
issue100: uWSGI 並列度・タイムアウトと PostgreSQL チューニングを環境変数で調整可能にする

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2026-06-26  Ichiro TAKAHASHI  <takahashi@fixpoint.co.jp>
+
+	* 標準シングル構成の PostgreSQL チューニング項目 (max_connections / shared_buffers / effective_cache_size / work_mem / maintenance_work_mem) を環境変数 POSTGRES_* で調整可能にしました。既定値は標準値のままです。(#100)
+
+	* 標準シングル構成の uWSGI ワーカ並列度・タイムアウト系 (UWSGI_PROCESSES / UWSGI_THREADS / UWSGI_LISTEN / UWSGI_HARAKIRI / UWSGI_THUNDER_LOCK) を環境変数で調整可能にしました。既定値は従来挙動と同じです。高負荷時の .wait / .recv によるワーカ枯渇を緩和できます。同時処理数を上げる場合は POSTGRES_MAX_CONNECTIONS も連動して引き上げてください。(#100)
+
+	* nginx の uwsgi タイムアウトを環境変数 KOMPIRA_NGINX_UWSGI_TIMEOUT (既定 300 秒) で調整可能にしました。(#100)
+
 2026-02-20  Ichiro TAKAHASHI  <takahashi@fixpoint.co.jp>
 
 	* create-cert.sh: Python 3.13 および厳格なSSL検証環境に対応しました。(#95)

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,7 +4,7 @@
 
 	* 標準シングル構成の uWSGI ワーカ並列度・タイムアウト系 (UWSGI_PROCESSES / UWSGI_THREADS / UWSGI_LISTEN / UWSGI_HARAKIRI / UWSGI_THUNDER_LOCK) を環境変数で調整可能にしました。既定値は従来挙動と同じです。高負荷時の .wait / .recv によるワーカ枯渇を緩和できます。同時処理数を上げる場合は POSTGRES_MAX_CONNECTIONS も連動して引き上げてください。(#100)
 
-	* nginx の uwsgi タイムアウトを環境変数 KOMPIRA_NGINX_UWSGI_TIMEOUT (既定 300 秒) で調整可能にしました。(#100)
+	* nginx の uwsgi read/send タイムアウトを環境変数 KOMPIRA_NGINX_UWSGI_READ_TIMEOUT / KOMPIRA_NGINX_UWSGI_SEND_TIMEOUT (各既定 300 秒) で個別に調整可能にしました。(#100)
 
 2026-02-20  Ichiro TAKAHASHI  <takahashi@fixpoint.co.jp>
 

--- a/configs/nginx.conf
+++ b/configs/nginx.conf
@@ -6,9 +6,10 @@ upstream django {
 # Specify the default charset
 charset utf-8;
 
-# uwsgi タイムアウトの設定
-uwsgi_send_timeout 300;
-uwsgi_read_timeout 300;
+# uwsgi タイムアウトの設定 (環境変数 KOMPIRA_NGINX_UWSGI_TIMEOUT で調整可能、既定 300 秒)
+# .wait / .recv を長め timeout で使う場合はこれ以上に、枯渇時に早期失敗させたい場合は短めに調整する。
+uwsgi_send_timeout ${KOMPIRA_NGINX_UWSGI_TIMEOUT};
+uwsgi_read_timeout ${KOMPIRA_NGINX_UWSGI_TIMEOUT};
 
 ### for KE: MAX_PATH_LENGTH=MAX_CHAR_LENGTH = 1024 ###
 # for reading large client request header. A request line cannot exceed the size of one buffer

--- a/configs/nginx.conf
+++ b/configs/nginx.conf
@@ -6,10 +6,10 @@ upstream django {
 # Specify the default charset
 charset utf-8;
 
-# uwsgi タイムアウトの設定 (環境変数 KOMPIRA_NGINX_UWSGI_TIMEOUT で調整可能、既定 300 秒)
+# uwsgi タイムアウトの設定 (環境変数で調整可能、既定 300 秒)。
 # .wait / .recv を長め timeout で使う場合はこれ以上に、枯渇時に早期失敗させたい場合は短めに調整する。
-uwsgi_send_timeout ${KOMPIRA_NGINX_UWSGI_TIMEOUT};
-uwsgi_read_timeout ${KOMPIRA_NGINX_UWSGI_TIMEOUT};
+uwsgi_send_timeout ${KOMPIRA_NGINX_UWSGI_SEND_TIMEOUT};
+uwsgi_read_timeout ${KOMPIRA_NGINX_UWSGI_READ_TIMEOUT};
 
 ### for KE: MAX_PATH_LENGTH=MAX_CHAR_LENGTH = 1024 ###
 # for reading large client request header. A request line cannot exceed the size of one buffer

--- a/ke2/services/kompira.yml
+++ b/ke2/services/kompira.yml
@@ -63,6 +63,15 @@ services:
       AUDIT_LOGGING_WHEN: ${KOMPIRA_AUDIT_LOGGING_WHEN:-${AUDIT_LOGGING_WHEN:-MIDNIGHT}}
       AUDIT_LOGGING_INTERVAL: ${KOMPIRA_AUDIT_LOGGING_INTERVAL:-${AUDIT_LOGGING_INTERVAL:-1}}
       UWSGI_BUFFER_SIZE: 65536
+      # uWSGI のワーカ並列度・タイムアウト系 (本体イメージの docker-entrypoint.sh が解釈する)。
+      # 既定値は本体の既定と同じ (processes=5, threads=1, listen=100, harakiri 無効, thunder-lock 無効)。
+      # 同時処理数 = processes x threads。上げる場合は postgres の max_connections も連動させること
+      # (processes x threads + 余裕 <= max_connections)。
+      UWSGI_PROCESSES: ${UWSGI_PROCESSES:-5}
+      UWSGI_THREADS: ${UWSGI_THREADS:-1}
+      UWSGI_LISTEN: ${UWSGI_LISTEN:-100}
+      UWSGI_HARAKIRI: ${UWSGI_HARAKIRI:-0}
+      UWSGI_THUNDER_LOCK: ${UWSGI_THUNDER_LOCK:-false}
     hostname: ap-${HOSTNAME:?HOSTNAME must be set}
     init: true
     command: ["uwsgi"]

--- a/ke2/services/kompira.yml
+++ b/ke2/services/kompira.yml
@@ -64,14 +64,16 @@ services:
       AUDIT_LOGGING_INTERVAL: ${KOMPIRA_AUDIT_LOGGING_INTERVAL:-${AUDIT_LOGGING_INTERVAL:-1}}
       UWSGI_BUFFER_SIZE: 65536
       # uWSGI のワーカ並列度・タイムアウト系 (本体イメージの docker-entrypoint.sh が解釈する)。
+      # コンテナへ渡すキー名 (UWSGI_*) は本体 entrypoint が読む名前なので変更しないこと。
+      # 値は他の変数同様 KOMPIRA_ 上書き → 無印 → 既定 の順で解決する。
       # 既定値は本体の既定と同じ (processes=5, threads=1, listen=100, harakiri 無効, thunder-lock 無効)。
       # 同時処理数 = processes x threads。上げる場合は postgres の max_connections も連動させること
       # (processes x threads + 余裕 <= max_connections)。
-      UWSGI_PROCESSES: ${UWSGI_PROCESSES:-5}
-      UWSGI_THREADS: ${UWSGI_THREADS:-1}
-      UWSGI_LISTEN: ${UWSGI_LISTEN:-100}
-      UWSGI_HARAKIRI: ${UWSGI_HARAKIRI:-0}
-      UWSGI_THUNDER_LOCK: ${UWSGI_THUNDER_LOCK:-false}
+      UWSGI_PROCESSES: ${KOMPIRA_UWSGI_PROCESSES:-${UWSGI_PROCESSES:-5}}
+      UWSGI_THREADS: ${KOMPIRA_UWSGI_THREADS:-${UWSGI_THREADS:-1}}
+      UWSGI_LISTEN: ${KOMPIRA_UWSGI_LISTEN:-${UWSGI_LISTEN:-100}}
+      UWSGI_HARAKIRI: ${KOMPIRA_UWSGI_HARAKIRI:-${UWSGI_HARAKIRI:-0}}
+      UWSGI_THUNDER_LOCK: ${KOMPIRA_UWSGI_THUNDER_LOCK:-${UWSGI_THUNDER_LOCK:-false}}
     hostname: ap-${HOSTNAME:?HOSTNAME must be set}
     init: true
     command: ["uwsgi"]

--- a/ke2/services/nginx.yml
+++ b/ke2/services/nginx.yml
@@ -7,6 +7,8 @@ services:
       - NGINX_ENVSUBST_FILTER=^KOMPIRA
       - KOMPIRA_HOST=${KOMPIRA_HOST:-kompira}
       - KOMPIRA_PORT=${KOMPIRA_PORT:-8000}
+      # uwsgi タイムアウト(秒)。envsubst は ${VAR:-default} 非対応のため既定値はここで与える
+      - KOMPIRA_NGINX_UWSGI_TIMEOUT=${KOMPIRA_NGINX_UWSGI_TIMEOUT:-300}
     configs:
       # MEMO: /etc/nginx/templates/*.template は起動時に環境変数が展開されて /etc/nginx/conf.d/* に書き出される
       - source: nginx-config

--- a/ke2/services/nginx.yml
+++ b/ke2/services/nginx.yml
@@ -7,8 +7,9 @@ services:
       - NGINX_ENVSUBST_FILTER=^KOMPIRA
       - KOMPIRA_HOST=${KOMPIRA_HOST:-kompira}
       - KOMPIRA_PORT=${KOMPIRA_PORT:-8000}
-      # uwsgi タイムアウト(秒)。envsubst は ${VAR:-default} 非対応のため既定値はここで与える
-      - KOMPIRA_NGINX_UWSGI_TIMEOUT=${KOMPIRA_NGINX_UWSGI_TIMEOUT:-300}
+      # uwsgi の read/send タイムアウト(秒)。envsubst は ${VAR:-default} 非対応のため既定値はここで与える
+      - KOMPIRA_NGINX_UWSGI_READ_TIMEOUT=${KOMPIRA_NGINX_UWSGI_READ_TIMEOUT:-300}
+      - KOMPIRA_NGINX_UWSGI_SEND_TIMEOUT=${KOMPIRA_NGINX_UWSGI_SEND_TIMEOUT:-300}
     configs:
       # MEMO: /etc/nginx/templates/*.template は起動時に環境変数が展開されて /etc/nginx/conf.d/* に書き出される
       - source: nginx-config

--- a/ke2/services/postgres.yml
+++ b/ke2/services/postgres.yml
@@ -3,10 +3,37 @@ services:
     # MEMO: potgrsql のメジャーバージョンを変更するときは PGDATA 領域のボリューム名も変更すること
     image: registry.hub.docker.com/library/postgres:16.3-alpine
     hostname: db-${HOSTNAME:?HOSTNAME must be set}
+    # PostgreSQL のチューニング項目を環境変数で調整可能にする。
+    # 既定値は postgres 16 の標準値なので、未指定なら従来挙動と同じ。
+    # シェル/.env でも docker-compose.override.yml の environment ブロックでも上書き可。
+    # [重要] uWSGI のワーカ並列度 (processes x threads) を上げると同時 DB 接続数が増えるため、
+    #        max_connections も連動して引き上げること。超過すると
+    #        "FATAL: sorry, too many clients already" で接続が拒否され、画面/API が 500 になる。
+    # 項目を追加する場合は environment に POSTGRES_<KEY> を足し、command にも
+    #        -c <key>="$$POSTGRES_<KEY>" を足す (例: max_wal_size 等)。
     environment:
       POSTGRES_PASSWORD: kompira
       POSTGRES_USER: kompira
       TZ: ${TZ:-Asia/Tokyo}
+      POSTGRES_MAX_CONNECTIONS: ${POSTGRES_MAX_CONNECTIONS:-100}
+      POSTGRES_SHARED_BUFFERS: ${POSTGRES_SHARED_BUFFERS:-128MB}
+      POSTGRES_EFFECTIVE_CACHE_SIZE: ${POSTGRES_EFFECTIVE_CACHE_SIZE:-4GB}
+      POSTGRES_WORK_MEM: ${POSTGRES_WORK_MEM:-4MB}
+      POSTGRES_MAINTENANCE_WORK_MEM: ${POSTGRES_MAINTENANCE_WORK_MEM:-64MB}
+    # command はコンテナ内シェルで環境変数を展開してから postgres を起動する。
+    # ($$ は compose のパース時置換を避けるエスケープ。これによりコンテナ実行時に
+    #  上記 environment の値=override.yml での上書きが反映される。
+    #  docker-entrypoint.sh 経由なので初回起動時の DB 初期化も従来どおり行われる)
+    command:
+      - sh
+      - -c
+      - >
+        exec docker-entrypoint.sh postgres
+        -c max_connections="$$POSTGRES_MAX_CONNECTIONS"
+        -c shared_buffers="$$POSTGRES_SHARED_BUFFERS"
+        -c effective_cache_size="$$POSTGRES_EFFECTIVE_CACHE_SIZE"
+        -c work_mem="$$POSTGRES_WORK_MEM"
+        -c maintenance_work_mem="$$POSTGRES_MAINTENANCE_WORK_MEM"
     volumes:
       - ${PGDATA:-kompira_pg16}:/var/lib/postgresql/data
 volumes:

--- a/ke2/single/basic/README.md
+++ b/ke2/single/basic/README.md
@@ -53,7 +53,8 @@ docker compose up するときに環境変数を指定することで、簡易�
 | `UWSGI_LISTEN`     | uWSGI の listen バックログ（既定 100）                                                       |
 | `UWSGI_HARAKIRI`   | uWSGI のリクエストタイムアウト秒（既定 0=無効）                                              |
 | `UWSGI_THUNDER_LOCK` | スレッド併用時の accept 公平化（既定 false。threads を増やす場合は true 推奨）             |
-| `KOMPIRA_NGINX_UWSGI_TIMEOUT` | nginx→uWSGI のタイムアウト秒（既定 300）。.wait/.recv を長め timeout で使う場合は連動して延ばす |
+| `KOMPIRA_NGINX_UWSGI_READ_TIMEOUT` | nginx→uWSGI の read タイムアウト秒（既定 300）。.wait/.recv を長め timeout で使う場合は連動して延ばす |
+| `KOMPIRA_NGINX_UWSGI_SEND_TIMEOUT` | nginx→uWSGI の send タイムアウト秒（既定 300） |
 
 なお、同時処理数（`UWSGI_PROCESSES`×`UWSGI_THREADS`）を増やす場合は、同時 DB 接続が
 増えるため `POSTGRES_MAX_CONNECTIONS` も連動して引き上げてください

--- a/ke2/single/basic/README.md
+++ b/ke2/single/basic/README.md
@@ -48,11 +48,22 @@ docker compose up するときに環境変数を指定することで、簡易�
 | `POSTGRES_EFFECTIVE_CACHE_SIZE` | プランナのキャッシュサイズ見積り（既定 4GB）                                     |
 | `POSTGRES_WORK_MEM` | クエリ毎のソート/ハッシュ作業メモリ（既定 4MB）                                            |
 | `POSTGRES_MAINTENANCE_WORK_MEM` | VACUUM・インデックス作成の作業メモリ（既定 64MB）                                |
+| `UWSGI_PROCESSES`  | Web サーバ(uWSGI)のワーカプロセス数（既定 5、目安は CPU コア数）                             |
+| `UWSGI_THREADS`    | ワーカ1プロセスあたりのスレッド数（既定 1）。同時処理数 = processes×threads。.wait/.recv 多用時に増やす |
+| `UWSGI_LISTEN`     | uWSGI の listen バックログ（既定 100）                                                       |
+| `UWSGI_HARAKIRI`   | uWSGI のリクエストタイムアウト秒（既定 0=無効）                                              |
+| `UWSGI_THUNDER_LOCK` | スレッド併用時の accept 公平化（既定 false。threads を増やす場合は true 推奨）             |
+| `KOMPIRA_NGINX_UWSGI_TIMEOUT` | nginx→uWSGI のタイムアウト秒（既定 300）。.wait/.recv を長め timeout で使う場合は連動して延ばす |
+
+なお、同時処理数（`UWSGI_PROCESSES`×`UWSGI_THREADS`）を増やす場合は、同時 DB 接続が
+増えるため `POSTGRES_MAX_CONNECTIONS` も連動して引き上げてください
+（目安: `processes×threads + 余裕(~15) <= max_connections`）。
 
 カスタマイズ例: 
 
     $ KOMPIRA_LOG_DIR=/var/log/kompira docker compose up -d
     $ POSTGRES_MAX_CONNECTIONS=200 POSTGRES_SHARED_BUFFERS=512MB docker compose up -d
+    $ UWSGI_PROCESSES=8 UWSGI_THREADS=8 UWSGI_THUNDER_LOCK=true POSTGRES_MAX_CONNECTIONS=200 docker compose up -d
 
 ### 詳細なカスタマイズ
 

--- a/ke2/single/basic/README.md
+++ b/ke2/single/basic/README.md
@@ -43,10 +43,16 @@ docker compose up するときに環境変数を指定することで、簡易�
 | 環境変数           | 備考                                                                                        |
 | ------------------ | ------------------------------------------------------------------------------------------- |
 | `KOMPIRA_LOG_DIR`  | ログファイルの出力先ディレクトリ（未指定の場合は kompira_log ボリューム内に出力されます）   |
+| `POSTGRES_MAX_CONNECTIONS` | PostgreSQL の最大同時接続数（既定 100）。Web の同時処理数（uWSGI の processes×threads）を増やす場合は連動して引き上げてください |
+| `POSTGRES_SHARED_BUFFERS` | PostgreSQL の共有バッファサイズ（既定 128MB）                                          |
+| `POSTGRES_EFFECTIVE_CACHE_SIZE` | プランナのキャッシュサイズ見積り（既定 4GB）                                     |
+| `POSTGRES_WORK_MEM` | クエリ毎のソート/ハッシュ作業メモリ（既定 4MB）                                            |
+| `POSTGRES_MAINTENANCE_WORK_MEM` | VACUUM・インデックス作成の作業メモリ（既定 64MB）                                |
 
 カスタマイズ例: 
 
     $ KOMPIRA_LOG_DIR=/var/log/kompira docker compose up -d
+    $ POSTGRES_MAX_CONNECTIONS=200 POSTGRES_SHARED_BUFFERS=512MB docker compose up -d
 
 ### 詳細なカスタマイズ
 


### PR DESCRIPTION
## 概要

高負荷時に Web ワーカ (uWSGI) が長時間占有され、画面や API 全体の応答が枯渇する事象を緩和するため、標準シングル構成の uWSGI ワーカ並列度・タイムアウト、PostgreSQL チューニング、nginx タイムアウトを環境変数で調整可能にします。いずれも**既定値は従来挙動を維持**するため、未指定なら現行と同じ動作です。

Fixes #100

## 変更内容

- **ke2/services/kompira.yml**: uWSGI のワーカ並列度・タイムアウト系を環境変数化。
  - `UWSGI_PROCESSES` (既定 5) / `UWSGI_THREADS` (1) / `UWSGI_LISTEN` (100) / `UWSGI_HARAKIRI` (0=無効) / `UWSGI_THUNDER_LOCK` (false)
  - 同時処理数 = `UWSGI_PROCESSES` × `UWSGI_THREADS`。
- **ke2/services/nginx.yml, configs/nginx.conf**: nginx→uWSGI のタイムアウトを `KOMPIRA_NGINX_UWSGI_TIMEOUT` (既定 300 秒) で調整可能に。
- **ke2/services/postgres.yml**: PostgreSQL の主要チューニング項目を環境変数化。
  - `POSTGRES_MAX_CONNECTIONS` (100) / `POSTGRES_SHARED_BUFFERS` (128MB) / `POSTGRES_EFFECTIVE_CACHE_SIZE` (4GB) / `POSTGRES_WORK_MEM` (4MB) / `POSTGRES_MAINTENANCE_WORK_MEM` (64MB)
- **ke2/single/basic/README.md**: これらの環境変数の説明を追記。
- **ChangeLog**: (#100) を追記。

## 注意

- **uWSGI の並列度 (processes × threads) を引き上げる場合は `POSTGRES_MAX_CONNECTIONS` も連動して引き上げてください。** 不足すると "FATAL: sorry, too many clients already" で接続が拒否され、画面/API が 500 になります (目安: processes × threads + 余裕 ≦ max_connections)。
- `UWSGI_*` は kompira 本体イメージの起動スクリプトが解釈する前提です。これらを解釈する対応イメージと組み合わせて有効になります (既定値では従来と同一のため、未対応イメージでも動作は変わりません)。
- 既定値はすべて従来挙動を維持しています。
