### PR TITLE
issue98/100: 環境変数ドキュメントを Environment.md に集約し各構成 README を再構成 (followup)

### DIFF
--- a/Environment.md
+++ b/Environment.md
@@ -4,7 +4,7 @@
 以下では各構成で共通的な環境変数について示します。
 各構成で独自の環境変数が定義されている場合もありますので、それぞれの説明を参照してください。
 
-> **デフォルト値の位置付け**: 以下の表に示す `DATABASE_URL` / `AMQP_URL` / `CACHE_URL` 等のデフォルト値は **kompira コンテナイメージ自体の既定値** であり、docker compose を経由せずコンテナを直接動かす場合などに参照されるものです。**ke2-docker の compose ファイルでは別途上書きされており**、内部 `postgres` / `rabbitmq` / `redis` コンテナへの接続情報 (`DATABASE_USER` / `DATABASE_PASSWORD` / `DATABASE_NAME` / `AMQP_USER` / `AMQP_PASSWORD` から組み立てた URL、または利用者が指定した `DATABASE_URL` / `AMQP_URL`) が実際の接続先として使われます。
+> **デフォルト値の位置付け**: 以下の表に示す `DATABASE_URL` / `AMQP_URL` / `CACHE_URL` 等のデフォルト値は **kompira コンテナイメージ自体のデフォルト値** であり、docker compose を経由せずコンテナを直接動かす場合などに参照されるものです。**ke2-docker の compose ファイルでは別途上書きされており**、内部 postgres / rabbitmq / redis コンテナへの接続情報 (`DATABASE_USER` / `DATABASE_PASSWORD` / `DATABASE_NAME` / `AMQP_USER` / `AMQP_PASSWORD` から組み立てた URL、または利用者が指定した `DATABASE_URL` / `AMQP_URL`) が実際の接続先として使われます。
 
 | 環境変数名            | デフォルト                                          | 意味                       |
 |-----------------------|-----------------------------------------------------|----------------------------|
@@ -19,8 +19,13 @@
 | `TZ`                  | "Asia/Tokyo"                                        | タイムゾーン               |
 | `LANGUAGE_CODE`       | "ja"                                                | 言語設定                   |
 | `MAX_EXECUTOR_NUM`    | "0"                                                 | Executor の最大数          |
+| `KOMPIRA_LOG_DIR`     | (下記参照)                                          | ログ出力先ディレクトリ     |
 | `LOGGING_XXX`         | (下記参照)                                          | プロセスログの設定         |
 | `AUDIT_LOGGING_XXX`   | (下記参照)                                          | 監査ログの設定             |
+| `UWSGI_XXX`           | (下記参照)                                          | uWSGI の並列度・タイムアウト |
+| `KOMPIRA_NGINX_UWSGI_READ_TIMEOUT` | "300"                                  | nginx→uWSGI の read タイムアウト (秒) |
+| `KOMPIRA_NGINX_UWSGI_SEND_TIMEOUT` | "300"                                  | nginx→uWSGI の send タイムアウト (秒) |
+| `POSTGRES_XXX`        | (下記参照)                                          | PostgreSQL のチューニング  |
 
 ## HOSTNAME
 
@@ -106,13 +111,15 @@ URL 安全でない文字を含むユーザ名・パスワード・DB 名を安�
 
 ## MAX_EXECUTOR_NUM
 
-Kompira エンジン上で動作する Executor プロセスの最大数を指定します。
-未設定または 0 を指定した場合は kengine コンテナの CPUコア数だけ Executor プロセスを起動します。
-なお、MAX_EXECUTOR_NUM を CPU コア数より多くしても、実行する Executor プロセス数は CPU コア数で抑えられます。
+Kompira エンジン (kengine) 上で動作する Executor プロセスの最大数を、**1 つの kengine あたり**で指定します。未設定または 0 の場合は、その kengine コンテナの CPU コア数に従います。明示的に上限を指定する場合は 1 以上の整数を指定してください。
 
-    プロセス数＝min(CPUコア数、MAX_EXECUTOR_NUM)
+1 つの kengine が起動する Executor 数は、その kengine の CPU コア数 (本値を指定した場合は CPU コア数と本値の小さい方) までです。さらに、**システム全体で動作する Executor の合計数は、導入されているライセンスで付与される最大 Executor 数に制限されます**。複数の kengine を動作させる構成 (Swarm など) では、各 kengine への割り当ては起動時にシステム全体の残り枠から配分されます。
 
-また、導入されているライセンスによっても実際に動作する Executor のプロセス数は制限されます。
+ジョブフローの並列実行数を増やしてスケールしたい場合は、ライセンスの購入とサーバリソース (CPU コア数・ノード) の増強で対応します。なお各 Executor は PostgreSQL への接続を 1 つ保持するため、Executor 数を増やす構成では接続先 PostgreSQL の最大接続数 (内部 postgres 構成では `POSTGRES_MAX_CONNECTIONS`、外部データベース構成では接続先 DB サーバ側で設定) の見積りにも反映してください。
+
+## KOMPIRA_LOG_DIR
+
+ログを保存する **ホスト側のディレクトリ** を指定します。指定するとコンテナ内の `/var/log/kompira` にバインドマウントされます。未指定の場合は、標準シングル構成・外部DBシングル構成では名前付きボリューム `kompira_log` に、Swarm 構成では共有ディレクトリ (`SHARED_DIR`) 配下の `log` ディレクトリに保存されます。(コンテナ内のログ出力パス自体は下記 `LOGGING_DIR` で指定します。)
 
 ## LOGGING_XXX / AUDIT_LOGGING_XXX
 
@@ -132,6 +139,7 @@ Kompira コンテナイメージにおけるプロセスログおよび監査ロ
     - デフォルトは 2 です。
 - `LOGGING_DIR` / `AUDIT_LOGGING_DIR`: ログの出力先ディレクトリを指定します。
     - デフォルトは "/var/log/kompira" です。標準的なデプロイ手順ではこのディレクトリはホストの kompira_log ボリュームにマウントされます。
+    - デフォルト (`/var/log/kompira`) から変更する場合は、変更先の出力ディレクトリがコンテナから書き込める形で用意されていることを確認してください。
 - `LOGGING_BACKUP`: ログローテート時に保存されるバックアップ数を指定します。
     - `LOGGING_BACKUP` のデフォルトは 7 です。
     - `AUDIT_LOGGING_BACKUP` のデフォルトは 365 です。
@@ -149,3 +157,46 @@ Kompira コンテナイメージにおけるプロセスログおよび監査ロ
 | "D"                 | 日                        |
 | "W0"-"W6"           | 曜日 (0=月曜)             |
 | "MIDNIGHT"          | 深夜0時                   |
+
+## UWSGI_XXX / KOMPIRA_NGINX_UWSGI_READ_TIMEOUT / KOMPIRA_NGINX_UWSGI_SEND_TIMEOUT
+
+kompira コンテナで動作する uWSGI (アプリケーションサーバ) のワーカ並列度・タイムアウトと、その前段の nginx から uWSGI へのタイムアウトを指定します。いずれも未設定ならデフォルト値で動作するため、通常はそのままで構いません。
+
+| 環境変数名           | デフォルト | 意味                                          |
+|----------------------|-----------|-----------------------------------------------|
+| `UWSGI_PROCESSES`    | "5"       | uWSGI のワーカプロセス数 (目安は CPU コア数)   |
+| `UWSGI_THREADS`      | "1"       | 1 ワーカあたりのスレッド数。同時処理数 = processes × threads |
+| `UWSGI_LISTEN`       | "100"     | 接続待ち行列 (listen backlog) の長さ           |
+| `UWSGI_HARAKIRI`     | "0"       | リクエスト処理のタイムアウト秒 (0 で無効)      |
+| `UWSGI_THUNDER_LOCK` | "false"   | 複数ワーカ/スレッドでの接続受け付けの公平化    |
+| `KOMPIRA_NGINX_UWSGI_READ_TIMEOUT` | "300" | nginx→uWSGI の read タイムアウト秒        |
+| `KOMPIRA_NGINX_UWSGI_SEND_TIMEOUT` | "300" | nginx→uWSGI の send タイムアウト秒        |
+
+以下のような場合に、環境変数の調整で改善できることがあります。
+
+- 高負荷でアクセスが全体的に遅い／同時処理数を上げたい → `UWSGI_PROCESSES` / `UWSGI_THREADS` / `UWSGI_THUNDER_LOCK`（あわせて `POSTGRES_MAX_CONNECTIONS` も連動）
+- 時間のかかる処理（大きなエクスポート・重いクエリなど）が完了前にタイムアウトで打ち切られてしまう → `KOMPIRA_NGINX_UWSGI_READ_TIMEOUT` / `KOMPIRA_NGINX_UWSGI_SEND_TIMEOUT`
+- 想定を超えて長時間実行され続けるリクエストがワーカを占有し続けるのを、一定時間で強制的に打ち切りたい → `UWSGI_HARAKIRI`
+- 短時間に接続が集中して、接続が拒否される・つながりにくくなる → `UWSGI_LISTEN`
+- 大規模データ環境で、搭載メモリに合わせて PostgreSQL を追加調整したい → `POSTGRES_SHARED_BUFFERS` / `POSTGRES_EFFECTIVE_CACHE_SIZE` / `POSTGRES_WORK_MEM` など (下記 POSTGRES_XXX 参照)
+
+並列度 (`UWSGI_PROCESSES` × `UWSGI_THREADS`) を上げる場合は、同時 DB 接続数も増えるため `POSTGRES_MAX_CONNECTIONS` (下記参照) も連動して引き上げてください。不足すると "FATAL: sorry, too many clients already" で接続が拒否されます。(外部データベース構成では `POSTGRES_MAX_CONNECTIONS` は無効で、接続先 DB サーバの `max_connections` を調整します。)
+
+調整の考え方や設定値の見積りの詳細は、管理者マニュアル「環境変数」章を参照してください。
+
+## POSTGRES_XXX
+
+内部 postgres コンテナを持つ構成 (標準シングル構成) で、PostgreSQL の主要なチューニング項目を指定します。外部データベース構成 (single/extdb・cluster/swarm) では内部 postgres を起動しないため対象外で、チューニングは接続先の外部 DB サーバ側で行います。いずれも未設定なら PostgreSQL の標準値で動作します。
+
+| 環境変数名                      | デフォルト | 対応する postgres 設定      |
+|---------------------------------|-----------|-----------------------------|
+| `POSTGRES_MAX_CONNECTIONS`      | "100"     | `max_connections`           |
+| `POSTGRES_SHARED_BUFFERS`       | "128MB"   | `shared_buffers`            |
+| `POSTGRES_EFFECTIVE_CACHE_SIZE` | "4GB"     | `effective_cache_size`      |
+| `POSTGRES_WORK_MEM`             | "4MB"     | `work_mem`                  |
+| `POSTGRES_MAINTENANCE_WORK_MEM` | "64MB"    | `maintenance_work_mem`      |
+
+- `POSTGRES_MAX_CONNECTIONS`: 受け付ける最大同時接続数です。上記の Web ワーカ並列度と連動して設定します。
+- メモリ関連パラメータ (`POSTGRES_SHARED_BUFFERS` / `POSTGRES_EFFECTIVE_CACHE_SIZE` / `POSTGRES_WORK_MEM` / `POSTGRES_MAINTENANCE_WORK_MEM`) は、ホストの搭載メモリを基準に決めます。
+
+各パラメータの詳細・見積りは、管理者マニュアル「環境変数」章および PostgreSQL のドキュメントを参照してください。

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,7 +23,7 @@
     - UWSGI_THREADS: ワーカプロセスあたりのスレッド数。同時処理数 = processes × threads (既定: 1)
     - UWSGI_LISTEN: リッスンキュー (backlog) の長さ (既定: 100)
     - UWSGI_HARAKIRI: リクエスト処理のタイムアウト秒。0 で無効 (既定: 0)
-    - UWSGI_THUNDER_LOCK: thundering herd を抑止するロックの有効化 (既定: false)
+    - UWSGI_THUNDER_LOCK: 複数ワーカ/スレッドへの接続を公平に振り分ける。threads を増やす場合は有効化を推奨 (既定: false)
 - nginx コンテナの uwsgi read/send タイムアウトを環境変数で調整可能にしました。
     - KOMPIRA_NGINX_UWSGI_READ_TIMEOUT: uwsgi からの応答読み取りタイムアウト秒 (既定: 300)
     - KOMPIRA_NGINX_UWSGI_SEND_TIMEOUT: uwsgi へのリクエスト送信タイムアウト秒 (既定: 300)

--- a/ke2/cloud/azureci/README.md
+++ b/ke2/cloud/azureci/README.md
@@ -159,11 +159,11 @@ Azure ポータルにログインして、ke20storage ストレージアカウ�
 画面上からアップロードすることも可能です。
 
 
-#### Nginx の conf ファイルのアップロード
+#### nginx の conf ファイルのアップロード
 
-Nginx の conf ファイルを kompira-nginx-conf ボリュームに default.conf という名称でアップロードします。
+nginx の conf ファイルを kompira-nginx-conf ボリュームに default.conf という名称でアップロードします。
 
-Azure CLI の以下のコマンドで ke2-docker に含まれる Nginx の conf ファイルをアップロードします。
+Azure CLI の以下のコマンドで ke2-docker に含まれる nginx の conf ファイルをアップロードします。
 
 ```
 cd .\ke2-docker
@@ -279,7 +279,7 @@ az deployment group create \
 
 - imageTag: イメージのタグ（デフォルト:  ke2-docker 更新時点で公開されていた最新の kompira コンテナイメージのタグ。例えば "2.0.2" など）
 - timezone: タイムゾーン（デフォルト: "Asia/Tokyo"）
-- maxExecutor: 最大エグゼキュター数（デフォルト: 2）
+- maxExecutor: 最大エグゼキュータ数（デフォルト: 2）
 - dnsNameLabel: DNS 名ラベル（デフォルト: 空）。
   DNS 名ラベルを追加する場合、`<dnsNameLabel>`.japaneast.azurecontainer.io にブラウザからアクセスできます。
 - databaseUrl: データベースの接続 URL 

--- a/ke2/cluster/swarm/README.md
+++ b/ke2/cluster/swarm/README.md
@@ -407,9 +407,11 @@ setup_stack.sh を実行するときに環境変数を指定することで、�
 | 環境変数           | 備考                                                                                        |
 | ------------------ | ------------------------------------------------------------------------------------------- |
 | `SHARED_DIR`       | 共有ディレクトリ（各ノードからアクセスできる必要があります）                                |
-| `DATABASE_URL`     | 外部データベース                                                                            |
+| `DATABASE_URL`     | 外部データベース (構築した Pgpool-II クラスタ) への接続 URL。未指定時は `DATABASE_HOST`（デフォルト: `host.docker.internal`）からデフォルト値を構築します |
 | `KOMPIRA_LOG_DIR`  | ログファイルの出力先ディレクトリ（未指定の場合は `${SHARED_DIR}/log` に出力されます）       |
-| `NGINX_PORT_MODE`  | Nginx の公開ポートモード (`host`、`ingress`) の設定（デフォルト: `ingress`） <br />`ingress`: HTTP(S) アクセスはクラスタを構成する各ホスト上の nginx コンテナに負荷分散されます。<br />`host`: HTTP(S) アクセスは URL で指定されたホスト上で動作する nginx コンテナが受信します。|                                                                  
+| `NGINX_PORT_MODE`  | nginx の公開ポートモード (`host`、`ingress`) の設定（デフォルト: `ingress`） <br />`ingress`: HTTP(S) アクセスはクラスタを構成する各ホスト上の nginx コンテナに負荷分散されます。<br />`host`: HTTP(S) アクセスは URL で指定されたホスト上で動作する nginx コンテナが受信します。|                                                                  
+
+これらは本構成に固有、またはデフォルト値が本構成固有の環境変数です。その他の共通の環境変数は [Environment.md](../../../Environment.md) を参照してください。
 
 カスタマイズ例: 
 

--- a/ke2/single/basic/README.md
+++ b/ke2/single/basic/README.md
@@ -38,27 +38,7 @@ docker compose up するときに環境変数を指定することで、簡易�
 
     $ 環境変数=値... docker compose up -d
 
-この構成で指定できるカスタマイズ用の環境変数を以下に示します。
-
-| 環境変数           | 備考                                                                                        |
-| ------------------ | ------------------------------------------------------------------------------------------- |
-| `KOMPIRA_LOG_DIR`  | ログファイルの出力先ディレクトリ（未指定の場合は kompira_log ボリューム内に出力されます）   |
-| `POSTGRES_MAX_CONNECTIONS` | PostgreSQL の最大同時接続数（既定 100）。Web の同時処理数（uWSGI の processes×threads）を増やす場合は連動して引き上げてください |
-| `POSTGRES_SHARED_BUFFERS` | PostgreSQL の共有バッファサイズ（既定 128MB）                                          |
-| `POSTGRES_EFFECTIVE_CACHE_SIZE` | プランナのキャッシュサイズ見積り（既定 4GB）                                     |
-| `POSTGRES_WORK_MEM` | クエリ毎のソート/ハッシュ作業メモリ（既定 4MB）                                            |
-| `POSTGRES_MAINTENANCE_WORK_MEM` | VACUUM・インデックス作成の作業メモリ（既定 64MB）                                |
-| `UWSGI_PROCESSES`  | Web サーバ(uWSGI)のワーカプロセス数（既定 5、目安は CPU コア数）                             |
-| `UWSGI_THREADS`    | ワーカ1プロセスあたりのスレッド数（既定 1）。同時処理数 = processes×threads。`.wait` / `.recv` 多用時に増やす |
-| `UWSGI_LISTEN`     | uWSGI の listen バックログ（既定 100）                                                       |
-| `UWSGI_HARAKIRI`   | uWSGI のリクエストタイムアウト秒（既定 0=無効）                                              |
-| `UWSGI_THUNDER_LOCK` | スレッド併用時の accept 公平化（既定 false。threads を増やす場合は true 推奨）             |
-| `KOMPIRA_NGINX_UWSGI_READ_TIMEOUT` | nginx→uWSGI の read タイムアウト秒（既定 300）。.wait/.recv を長め timeout で使う場合は連動して延ばす |
-| `KOMPIRA_NGINX_UWSGI_SEND_TIMEOUT` | nginx→uWSGI の send タイムアウト秒（既定 300） |
-
-なお、同時処理数（`UWSGI_PROCESSES`×`UWSGI_THREADS`）を増やす場合は、同時 DB 接続が
-増えるため `POSTGRES_MAX_CONNECTIONS` も連動して引き上げてください
-（目安: `processes×threads + 余裕(~15) <= max_connections`）。
+この構成で指定できる環境変数は各構成で共通のため、[Environment.md](../../../Environment.md) を参照してください。よく使う指定例を以下に示します。
 
 カスタマイズ例: 
 

--- a/ke2/single/extdb/README.md
+++ b/ke2/single/extdb/README.md
@@ -111,20 +111,11 @@ docker compose up するときに環境変数を指定することで、簡易�
 
     $ 環境変数=値... docker compose up -d
 
-この構成で指定できる環境変数を以下に示します。
-
-| 環境変数           | 備考                                                                                              |
-| ------------------ | ------------------------------------------------------------------------------------------------- |
-| `DATABASE_URL`     | 外部データベースの接続 URL。**必須**。未指定の場合は起動時にエラー停止します                      |
-| `AMQP_USER`        | 内部 RabbitMQ コンテナのユーザ名（デフォルト: `guest`）                                           |
-| `AMQP_PASSWORD`    | 内部 RabbitMQ コンテナのパスワード（デフォルト: `guest`、本番運用前に変更を強く推奨）             |
-| `KOMPIRA_LOG_DIR`  | ログファイルの出力先ディレクトリ（未指定の場合は kompira_log ボリューム内に出力されます）         |
+この構成では、外部データベースへの接続情報として `DATABASE_URL` の指定が **必須** です（未指定の場合は `docker compose config` の段階でエラー停止します）。その他の環境変数は各構成で共通のため、[Environment.md](../../../Environment.md) を参照してください。
 
 カスタマイズ例:
 
     $ DATABASE_URL='pgsql://...' AMQP_PASSWORD='strong-pw' KOMPIRA_LOG_DIR=/var/log/kompira docker compose up -d
-
-> **AMQP の資格情報に URL 安全でない文字 (`@` `:` `/` `%` や空白等、RFC 3986 unreserved 以外の文字) を含めたい場合**: `AMQP_USER` / `AMQP_PASSWORD` から compose が `AMQP_URL` を組み立てる際は未エンコードのまま URL に埋め込まれるため、これらの変数には unreserved set (英数字と `-_.~`) のみを使用してください。予約文字を含めたい場合は、あらかじめパーセントエンコードした `AMQP_URL` を直接指定してください。この場合、AMQP_URL の userinfo をデコードするために KE2.0 コンテナイメージが **v2.0.5.post2 以降** である必要があります (v2.0.5.post1 以前のイメージではデコードされず認証に失敗します)。
 
 ### 詳細なカスタマイズ
 


### PR DESCRIPTION
## 概要

2026/07/10 リリース (`20260710-2.0.5-latest`, #98 / #100) で追加された環境変数について、リリース後のドキュメント整備を行う followup です。当初は各説明の明確化から始めましたが、レビューを通じて **環境変数ドキュメント全体の情報アーキテクチャを再構成** する内容になりました。**機能変更はありません (ドキュメントのみ)**。

## 情報アーキテクチャ（3層）

`Environment.md` 冒頭の既存方針「共通的な環境変数は Environment.md／構成固有は各構成の説明」に沿って整理しました。

- **各構成 README**（`ke2/single/basic` ほか）＝ その構成に**固有の環境変数**＋ `Environment.md` への誘導
- **ルート `Environment.md`** ＝ ke2-docker 共通の**環境変数リファレンス**（全共通変数の説明＋「課題→変数」ナビ）
- **管理者マニュアル「環境変数」章** ＝ 運用・チューニングの**詳細指針**（`Environment.md` から誘導。別リポジトリ）

参照の流れ: 各構成 README →（共通の詳細）Environment.md →（調整の考え方・見積り）管理者マニュアル。

## 主な変更

### Environment.md（共通リファレンスの拡充）
- uWSGI 並列度・タイムアウト（`UWSGI_*` / `KOMPIRA_NGINX_UWSGI_*`）、PostgreSQL チューニング（`POSTGRES_*`）の説明を追加。
- 「どんな課題のときにどの変数を調整するか」のナビを集約。
- 共通変数 `KOMPIRA_LOG_DIR` を追記（ログ保存先＝ホスト側ディレクトリ。コンテナ内パスを指定する `LOGGING_DIR` との違いを明記）。
- `MAX_EXECUTOR_NUM` にスケール方針・Executor と `POSTGRES_MAX_CONNECTIONS` の関連を追記。
- 表記を管理者マニュアル規約に統一（`Nginx`→`nginx`、コンテナ名は素の小文字、`CPU コア数` 等）。

### 各構成 README（固有変数＋誘導に再構成）
- **single/basic**: 共通変数の表を撤去し、`Environment.md` 参照＋カスタマイズ例に。
- **single/extdb**: `DATABASE_URL` 必須の注記＋`Environment.md` 参照に。
- **cluster/swarm**: 固有/既定が構成固有の変数（`SHARED_DIR` / `DATABASE_URL` / `KOMPIRA_LOG_DIR` / `NGINX_PORT_MODE`）のみ表に残し、共通変数は `Environment.md` 参照に。
- **extra/jobmngrd**: 該当するチューニング変数なし（変更なし）。

### #98 followup（資格情報）
- 資格情報の初回起動時のみ反映される旨などの注意を `Environment.md` に集約。

## 備考

- ChangeLog は未更新（doc-only のため）。
- `cloud/azureci` は ARM テンプレート機構のため本 PR のスコープ外（別途）。
- コミットは細粒度のまま（後で整理予定）。
- 管理者マニュアル側の対応（環境変数チューニング指針の場面別整備、`KOMPIRA_LOG_DIR` 追記）は ke2-admin-manual の別 PR で進行中。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
