### PR TITLE
setup_stack.sh: cluster/swarm 実機構築で判明した失敗要因・移植性を修正

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2026-07-14  Ichiro TAKAHASHI  <takahashi@fixpoint.co.jp>
+
+	* cluster/swarm 構成の setup_stack.sh を、実機構築で判明した失敗要因・移植性の問題について修正しました。共有ディレクトリ (SHARED_DIR) が root など実行ユーザ以外の所有でも SSL 証明書のコピーが失敗しないようにし (cp --preserve=mode)、非対話シェルで HOSTNAME 未設定でも docker-swarm.yml を生成できるよう補完し、SHARED_DIR 未指定時や SSL 未生成時には分かりやすいエラーで停止するようにしました。あわせて pipefail の追加・エラー出力の統一・シェバンの明示化 (#!/bin/bash) を行っています。(setup-stack-ssl-hostname)
+
 2026-07-06  Ichiro TAKAHASHI  <takahashi@fixpoint.co.jp>
 
 	* 各サービスの資格情報を個別の環境変数 (DATABASE_USER / DATABASE_PASSWORD / DATABASE_NAME / AMQP_USER / AMQP_PASSWORD) で指定可能にしました。既定値は従来値 (kompira / guest) のままなので、未指定なら従来挙動と同じです。(#98)

--- a/ke2/cluster/swarm/setup_stack.sh
+++ b/ke2/cluster/swarm/setup_stack.sh
@@ -1,34 +1,63 @@
-#! /bin/sh
+#!/bin/bash
 
-set -eu
+# pipefail: `docker compose config | sed ...` で compose 側の失敗が sed 成功に
+# マスクされ、不完全な docker-swarm.yml のまま続行するのを防ぐ (bash 依存)。
+set -euo pipefail
+
+# SHARED_DIR は共有ディレクトリのパスとして必須 (以降の KOMPIRA_*_DIR の既定値が参照する)。
+# set -u 任せだと汎用的な "unbound variable" になるため、明示的に案内する。
+: ${SHARED_DIR:?"環境変数 SHARED_DIR (共有ディレクトリのパス) を指定してください"}
+
 : ${KOMPIRA_LOG_DIR:=$SHARED_DIR/log}
 : ${KOMPIRA_VAR_DIR:=$SHARED_DIR/var}
 : ${KOMPIRA_SSL_DIR:=$SHARED_DIR/ssl}
 : ${DATABASE_URL:=""}
 : ${DATABASE_HOST:="host.docker.internal"}
+# HOSTNAME はサービス定義 (redis 等の hostname: re-${HOSTNAME}) で参照される。
+# 非対話シェル (スクリプト実行や CI 等) では未設定のことがあるため、ここで補完する。
+: ${HOSTNAME:=$(hostname)}
 
 if [ ! -w "$KOMPIRA_LOG_DIR" ]; then
-    echo "ERROR: KOMPIRA_LOG_DIR ($KOMPIRA_LOG_DIR) is not writable" > /dev/stderr
+    echo "ERROR: KOMPIRA_LOG_DIR ($KOMPIRA_LOG_DIR) is not writable" >&2
     exit 1
 fi
 if [ ! -w "$KOMPIRA_VAR_DIR" ]; then
-    echo "ERROR: KOMPIRA_VAR_DIR ($KOMPIRA_VAR_DIR) is not writable" > /dev/stderr
+    echo "ERROR: KOMPIRA_VAR_DIR ($KOMPIRA_VAR_DIR) is not writable" >&2
     exit 1
 fi
 if [ ! -w "$KOMPIRA_SSL_DIR" ]; then
-    echo "ERROR: KOMPIRA_SSL_DIR ($KOMPIRA_SSL_DIR) is not writable" > /dev/stderr
+    echo "ERROR: KOMPIRA_SSL_DIR ($KOMPIRA_SSL_DIR) is not writable" >&2
     exit 1
 fi
 if [ -z "$DATABASE_URL" ]; then
     if [ -z "$DATABASE_HOST" ]; then
-        echo "ERROR: DATABASE_URL or DATABASE_HOST is required" > /dev/stderr
+        echo "ERROR: DATABASE_URL or DATABASE_HOST is required" >&2
         exit 1
     fi
     DATABASE_URL="pgsql://kompira:kompira@$DATABASE_HOST:9999/kompira"
 fi
 
 # SSL 証明書を共有ディレクトリにコピーする
-/bin/cp -f -a -r -T ../../../ssl $KOMPIRA_SSL_DIR
+# ssl/ に証明書ファイルがあることを確認する。空 (未生成・.gitignore のみ) だと glob `ssl/*` が
+# 展開されず、set -e 配下で不明瞭な cp エラーになるため、明示的に案内して停止する。
+shopt -s nullglob
+_ssl_files=(../../../ssl/*)
+shopt -u nullglob
+if [ ${#_ssl_files[@]} -eq 0 ]; then
+    echo "ERROR: ../../../ssl に証明書がありません。先に scripts/create-cert.sh を実行してください" >&2
+    exit 1
+fi
+# 既定構成の nginx / rabbitmq は server.crt / server.key / local-ca.crt を参照する。
+# 既定名が欠けている場合は警告する (create-cert.sh の CERT_NAME/CA_NAME でカスタム名や複数ペアを
+# 使う運用もあり得るため、ここでは停止せず警告に留める。その場合は各 SSL 設定側の参照も合わせること)。
+for _ssl_file in server.crt server.key local-ca.crt; do
+    [ -f "../../../ssl/${_ssl_file}" ] || echo "WARNING: 既定の SSL ファイル ssl/${_ssl_file} が見つかりません (カスタム証明書名の場合は設定側の参照を確認してください)" >&2
+done
+# -a ではなく --preserve=mode を用いる: SHARED_DIR が別ユーザ所有 (root が作成した共有
+# ディレクトリ等) でも、書き込み可能でありさえすれば失敗しないようにする。ディレクトリの
+# 時刻・所有者は複製せず (非所有だと -a の時刻保持が EPERM で失敗する)、秘密鍵などの
+# ファイルモード (例: server.key の 600) は保持する。
+/bin/cp -f -r --preserve=mode -- "${_ssl_files[@]}" "$KOMPIRA_SSL_DIR/"
 echo "OK: SSL files have been copied to the shared directory"
 
 # ホスト名がロング形式であるかを判定して環境変数 RABBITMQ_USE_LONGNAME に反映する
@@ -37,14 +66,14 @@ export RABBITMQ_USE_LONGNAME=$([ $(hostname) == $(hostname -s) ] && echo 'false'
 # docker stack deploy 用の docker-swarm.yml ファイルを準備する
 # MEMO: docker compose config の結果はそのままでは docker stack が扱えない場合がある
 # 一部の項目について正規化することで docker stack でも扱えるようにする
-export KOMPIRA_LOG_DIR KOMPIRA_VAR_DIR KOMPIRA_SSL_DIR DATABASE_URL
+export KOMPIRA_LOG_DIR KOMPIRA_VAR_DIR KOMPIRA_SSL_DIR DATABASE_URL HOSTNAME
 docker compose config | sed -r -e '/^name:/d' -e 's/"([0-9]+)"/\1/' -e 's/<<(.*)>>/{{\1}}/' > docker-swarm.yml
 echo "OK: docker-swarm.yml prepared"
 
 # services.rabbitmq.hostname のフォーマットを取得する
 rabbitmq_hostname_format=$(cat docker-swarm.yml | sed -nre '/^\s+rabbitmq:/,/^\s+hostname:/p' | sed -nre 's/^\s*hostname:\s*(.*)/\1/p')
 if [ -z "$rabbitmq_hostname_format" ]; then
-    echo "ERROR: rabbitmq hostname format could not be identified." > /dev/stderr
+    echo "ERROR: rabbitmq hostname format could not be identified." >&2
     exit 1
 fi
 # rabbitmq-cluster.conf を準備する
@@ -59,7 +88,7 @@ fi
         echo "cluster_formation.classic_config.nodes.$node_index = rabbit@$rabbitmq_hostname"
     done
     if [ $node_index == 0 ]; then
-        echo "ERROR: Swarm node list could not be retrieved." > /dev/stderr
+        echo "ERROR: Swarm node list could not be retrieved." >&2
         exit 1
     fi
 ) > ./rabbitmq-cluster.conf


### PR DESCRIPTION
## 概要

cluster/swarm 構成を素の Rocky Linux 9 × 3 台で実機構築・検証した際に判明した `ke2/cluster/swarm/setup_stack.sh` の実行時失敗要因・移植性の問題を修正します。（PR レビュー（Copilot）での指摘を反映し、当初の 3 点から拡張しています。）

## 変更点

- **SSL コピーの EPERM 停止**: `cp -f -a -r -T ../../../ssl $KOMPIRA_SSL_DIR` は SHARED_DIR が実行ユーザ以外（root が作成した共有ディレクトリ等）の所有だと `-a` の時刻・所有者保持がコピー先ディレクトリに対して EPERM となり `set -e` で中断していた。`cp -f -r --preserve=mode -- "${_ssl_files[@]}" "$KOMPIRA_SSL_DIR/"` に変更（中身のみコピーしてコピー先ディレクトリ自身の属性は変更せず、秘密鍵のモード＝`server.key` の 600 は保持。option 誤認防止に `--` を付与）。
- **SSL 証明書チェック（ハイブリッド）**: `ssl/` が空（未生成・`.gitignore` のみ）は ERROR 停止（glob 未展開による不明瞭な `cannot stat` を回避）。既定構成の nginx / rabbitmq が参照する `server.crt` / `server.key` / `local-ca.crt` の欠落は WARNING に留める（`create-cert.sh` の `CERT_NAME` / `CA_NAME` でカスタム名・複数ペアを使う運用もあり得るため、既定名は強制しない。その場合は各 SSL 設定側の参照も合わせる）。
- **stderr 出力の統一**: `echo ... > /dev/stderr` は stderr が通常ファイル（ログ収集や `2>&1`）だと truncate/clobber され、後続の stdout 出力で警告が消える。`>&2` に統一（8 箇所）。
- **SHARED_DIR の必須チェック**: 未設定だと `set -u` 任せで汎用的な "unbound variable" になるため、`: ${SHARED_DIR:?...}` で共有ディレクトリのパス指定を促す actionable なエラーにした。
- **HOSTNAME 未設定での失敗**: `docker compose config` はサービス定義の hostname（redis 等の `re-${HOSTNAME:?...}`）で `HOSTNAME` を要求するが、非対話シェル（スクリプト実行や CI）では未設定で失敗していた。`: ${HOSTNAME:=$(hostname)}` で補完し `export` に追加。
- **pipefail**: `docker compose config | sed ...` で compose 側の失敗が sed 成功にマスクされ、不完全な `docker-swarm.yml` のまま "OK" と表示して続行しうる。`set -o pipefail` を追加。
- **シェバンの明示化**: `#! /bin/sh` を掲げつつ `[ ... == ... ]`（bash 拡張、POSIX test 非対応）を使っており dash では動かなかった。実体（bash + GNU coreutils + Linux 前提）に合わせ、同ディレクトリの他スクリプトと同水準で `#!/bin/bash` に統一。

## 実機検証（Rocky Linux 9 × 3 クラスタ）

- **エンドツーエンド（最終版）**: 最終版スクリプトで docker-swarm.yml を生成 → `docker stack deploy` → 全サービス 3/3 収束 → DB/AMQP 認証エラー 0 → テストジョブフロー `DONE`（`result=42`、リモートジョブ `['hostname']` が jobmngrd で実行＝kengine↔jobmngrd の AMQP 経路も機能）を確認。
- **個別**: SSL コピー EPERM 回避（`server.key` 600 保持）/ `ssl/` 空→ERROR・既定名欠落→WARNING（一括 `2>&1` でも残存）/ SHARED_DIR 未設定→専用メッセージで停止 / `docker compose config` 失敗を pipefail が捕捉して非ゼロ終了・"OK" 非出力 / HOSTNAME 未設定でも `docker-swarm.yml` 生成、をいずれも確認。

## 補足（スコープ外・別途）

- 本 PR は cluster/swarm 構築検証（ke2-admin-manual #26 followup）から派生した ke2-docker 側のフォローアップです。
- ホスト実行スクリプト全体の互換性（Linux/GNU coreutils 前提、cluster/swarm は RHEL9/systemd/SELinux、macOS 非対応、`create-cert.sh` の `readlink -f` 等）は棚卸し済みで、制限緩和は別 Issue で検討する想定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
