### PR TITLE
cluster/swarm 更新時の注意（docker-swarm.yml 再生成）を追記

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,6 +43,9 @@
     - reload-cert.sh を非対話 (非 TTY) 実行でも動作するように改善しました。
     - .gitattributes を追加して改行コードを LF に正規化しました。
 
+### アップデート時の注意
+- cluster/swarm 構成を更新する場合は、git pull などでリポジトリを更新した後に、**必ず setup_stack.sh を再実行して docker-swarm.yml を作り直してから docker stack deploy してください**。以前生成した古い docker-swarm.yml を使い回すと、更新後の設定ファイル (configs/) と環境変数が不整合になり、一部のコンテナが正しく起動しない、または変更した設定が反映されないことがあります。また setup_stack.sh はその時点の環境変数から docker-swarm.yml を生成するため、**初回構築や前回までのアップデートで指定した環境変数を今回も指定してください** (省略すると DATABASE_URL・資格情報・チューニング系などが既定値に戻ります)。
+
 ---
 ## 2026/03/06 (2.0.5-latest)
 ### 変更

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -44,7 +44,9 @@
     - .gitattributes を追加して改行コードを LF に正規化しました。
 
 ### アップデート時の注意
-- cluster/swarm 構成を更新する場合は、git pull などでリポジトリを更新した後に、**必ず setup_stack.sh を再実行して docker-swarm.yml を作り直してから docker stack deploy してください**。以前生成した古い docker-swarm.yml を使い回すと、更新後の設定ファイル (configs/) と環境変数が不整合になり、一部のコンテナが正しく起動しない、または変更した設定が反映されないことがあります。また setup_stack.sh はその時点の環境変数から docker-swarm.yml を生成するため、**初回構築や前回までのアップデートで指定した環境変数を今回も指定してください** (省略すると DATABASE_URL・資格情報・チューニング系などが既定値に戻ります)。
+- cluster/swarm 構成を更新する場合は、以下に注意してください。
+    - ke2-docker を更新 (git pull など) した後、docker stack deploy の前に必ず setup_stack.sh を再実行して docker-swarm.yml を作り直してください。以前生成した古い docker-swarm.yml を使い回すと、更新後の設定ファイル (configs/) と環境変数が不整合になり、一部のコンテナが正しく起動しない、または変更した設定が反映されないことがあります。
+    - setup_stack.sh はその時点の環境変数から docker-swarm.yml を生成するため、初回構築や前回までのアップデートで指定していた環境変数を今回も指定してください。省略すると DATABASE_URL・資格情報・チューニング系などが既定値に戻ります。
 
 ---
 ## 2026/03/06 (2.0.5-latest)

--- a/ke2/cluster/swarm/README.md
+++ b/ke2/cluster/swarm/README.md
@@ -399,7 +399,10 @@ Kompira Enterprise を停止するには以下のコマンドを実行します�
 
 ## 更新時の注意
 
-ke2-docker を更新 (git pull など) した後に再デプロイする場合は、**必ず setup_stack.sh を再実行して docker-swarm.yml を作り直してから docker stack deploy してください**。以前生成した古い docker-swarm.yml を使い回すと、更新後の設定ファイル (configs/) と環境変数が不整合になり、一部のコンテナが正しく起動しない、または変更した設定が反映されないことがあります。また setup_stack.sh はその時点の環境変数から docker-swarm.yml を生成するため、**初回構築や前回までのアップデートで指定した環境変数を今回も指定してください** (省略すると DATABASE_URL・資格情報・チューニング系などが既定値に戻ります)。
+ke2-docker を更新 (git pull など) した後に再デプロイする場合は、以下に注意してください。
+
+- git pull などでリポジトリを更新した後、`docker stack deploy` の前に必ず `setup_stack.sh` を再実行して `docker-swarm.yml` を作り直してください。以前生成した古い `docker-swarm.yml` を使い回すと、更新後の設定ファイル (`configs/`) と環境変数が不整合になり、一部のコンテナが正しく起動しない、または変更した設定が反映されないことがあります。
+- `setup_stack.sh` はその時点の環境変数から `docker-swarm.yml` を生成するため、初回構築や前回までのアップデートで指定していた環境変数を今回も指定してください (省略すると `DATABASE_URL`・資格情報・チューニング系などが既定値に戻ります)。
 
 ## カスタマイズ
 ### 環境変数によるカスタマイズ

--- a/ke2/cluster/swarm/README.md
+++ b/ke2/cluster/swarm/README.md
@@ -397,6 +397,10 @@ Kompira Enterprise を停止するには以下のコマンドを実行します�
 
 	$ docker stack rm ke2
 
+## 更新時の注意
+
+ke2-docker を更新 (git pull など) した後に再デプロイする場合は、**必ず setup_stack.sh を再実行して docker-swarm.yml を作り直してから docker stack deploy してください**。以前生成した古い docker-swarm.yml を使い回すと、更新後の設定ファイル (configs/) と環境変数が不整合になり、一部のコンテナが正しく起動しない、または変更した設定が反映されないことがあります。また setup_stack.sh はその時点の環境変数から docker-swarm.yml を生成するため、**初回構築や前回までのアップデートで指定した環境変数を今回も指定してください** (省略すると DATABASE_URL・資格情報・チューニング系などが既定値に戻ります)。
+
 ## カスタマイズ
 ### 環境変数によるカスタマイズ
 


### PR DESCRIPTION
## 概要

cluster/swarm 構成のアップデート／再デプロイ時に、以前生成した古い `docker-swarm.yml` を使い回すと、更新後の設定ファイル (`configs/`) と環境変数が不整合になり、一部のコンテナが正しく起動しない、または変更した設定が反映されないことがあります。これを避けるための注意書きをドキュメントに追加します。

Docker Swarm の config は不変 (immutable) で、`docker-swarm.yml` は `setup_stack.sh` 実行時点の環境変数から生成されるため、更新時は必ず `setup_stack.sh` を再実行して `docker-swarm.yml` を作り直す必要があります。

## 変更点

- `ke2/cluster/swarm/README.md`: 「更新時の注意」節を追加
- `RELEASE-NOTES.md`: 「アップデート時の注意」を追加（リリースをまたいで繰り越す想定のブロック）

いずれもドキュメントのみで、設定・スクリプトの挙動変更はありません。

## 補足

- `setup_stack.sh` の再実行時に、初回構築や前回までのアップデートで指定していた環境変数（`DATABASE_URL`・資格情報・チューニング系など）を今回も指定しないと、`docker-swarm.yml` が既定値で再生成される点も明記しています。
- ChangeLog は本 PR の対象外です（別途対応）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
